### PR TITLE
add benchmark for getItem

### DIFF
--- a/benchmark/src/androidTest/java/com/github/sckm/itemgroup/benchmark/ItemGroupBenchmark.kt
+++ b/benchmark/src/androidTest/java/com/github/sckm/itemgroup/benchmark/ItemGroupBenchmark.kt
@@ -65,6 +65,34 @@ class ItemGroupBenchmark {
         }
     }
 
+    @Test
+    fun benchmarkItemGroupGetItem() {
+        val items = generateItems()
+        val section = ItemGroup()
+        section.addAll(items)
+
+        benchmarkRule.measureRepeated {
+            (0 until items.size).forEach {
+                section.getItem(it)
+            }
+        }
+    }
+
+
+    @Test
+    fun benchmarkSectionGetItem() {
+        val items = generateItems()
+        val section = Section()
+        section.addAll(items)
+
+        benchmarkRule.measureRepeated {
+            (0 until items.size).forEach {
+                section.getItem(it)
+            }
+        }
+    }
+
+
     private fun generateItems(): List<Item<*>> {
         return (0L..100L).map { id -> BenchmarkItem(Data(id, id.toString())) }
     }


### PR DESCRIPTION
## Overview
add benchmark test for getItem

## Benchmark Result
```
Started running tests
benchmark:       292,396 ns ItemGroupBenchmark.benchmarkSectionGetItem
benchmark:         6,659 ns ItemGroupBenchmark.benchmarkItemGroupGetItem

benchmark:     1,559,323 ns ItemGroupBenchmark.benchmarkSectionUpdateNoChanged
benchmark:        60,327 ns ItemGroupBenchmark.benchmarkItemGroupUpdateNoChanged

benchmark:    82,372,500 ns ItemGroupBenchmark.benchmarkSectionUpdateShuffled
benchmark:     1,999,323 ns ItemGroupBenchmark.benchmarkItemGroupUpdateShuffled
```